### PR TITLE
Fey'ri consistency

### DIFF
--- a/subrace/lang/en_us/subrace.tra
+++ b/subrace/lang/en_us/subrace.tra
@@ -227,8 +227,9 @@ Moon elves have the following traits:
 @1121  = ~FEY'RI: Fey'ri are elven-based planetouched with a hint of the fiendish in their bloodline, which predisposes them to mischievous and chaotic behavior, but not necessarily to evil. Though their appearance can be very elven-like, to the point where they are sometimes indistinguishable from regular elves, they often have telltale signs that belie their ancestry such as fangs, barbed tails, horns, forked tongues, and even wings in some rare cases. Due to the misconceptions about their nature, and the assumption of evil, they face a lot of discrimination in a similar way tieflings do.
 
 Fey'ri have the following traits:
+– Infravision
 – May cast Blindness once per day
-– +1 Charisma
+– +1 Intelligence, +1 Dexterity, -1 Charisma
 – Fire, cold, and electrical resistance: +15%
 – +10% Hide in Shadows and Move Silently
 – Gets only 95% of all experience gained~

--- a/subrace/lib/subrace.tph
+++ b/subrace/lib/subrace.tph
@@ -248,14 +248,18 @@ COPY ~subrace/spl/spell.spl~ ~override/sr_feyri.spl~
    //Hair color
     LPF ADD_SPELL_EFFECT INT_VAR opcode=7 target=2 timing=9  parameter1=19 parameter2=6 END
   END
-   //Charisma +1
-  LPF ADD_SPELL_EFFECT INT_VAR opcode=6 target=2 timing=1  parameter1=1 END
+  //intelligence +1
+  LPF ADD_SPELL_EFFECT INT_VAR opcode=19 target=2 timing=1 parameter1=1 END
    //Dexterity +1
-  LPF ADD_SPELL_EFFECT INT_VAR opcode=15 target=2 timing=1  parameter1=1 END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode=15 target=2 timing=1 parameter1=1 END
+   //Charisma -1
+  LPF ADD_SPELL_EFFECT INT_VAR opcode=6 target=2 timing=1  parameter1="-1" END
   // elemental resistances
   PATCH_FOR_EACH resistance IN 28 29 30 BEGIN
     LPF ADD_SPELL_EFFECT INT_VAR opcode=resistance target=2 timing=9 parameter1=15 END
   END
+   //Infravision
+  LPF ADD_SPELL_EFFECT INT_VAR opcode=63 target=2 timing=9 END
   //Give innate ability
   LPF ADD_SPELL_EFFECT INT_VAR opcode=171 target=2 timing=9  STR_VAR resource="srblind" END
   //XP bonus - 95%


### PR DESCRIPTION
For consistency with tieflings and the change from elven subrace to half-elven subrace, fey'ri now have the exact same benefits as tieflings, while still being considering half-elves